### PR TITLE
Added us localization. If default uses "," instead of "."

### DIFF
--- a/GPS-Simulator/MainWindow.xaml.cs
+++ b/GPS-Simulator/MainWindow.xaml.cs
@@ -75,7 +75,7 @@ namespace GPS_Simulator
         /// </summary>
         public MainWindow()
         {
-            CultureInfo.CurrentCulture = new CultureInfo("th-TH", false);
+            CultureInfo.CurrentCulture = new CultureInfo("en-US", false);
             InitializeComponent();
 
             // default is walking

--- a/GPS-Simulator/MainWindow.xaml.cs
+++ b/GPS-Simulator/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.Maps.MapControl.WPF;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 
@@ -74,6 +75,7 @@ namespace GPS_Simulator
         /// </summary>
         public MainWindow()
         {
+            CultureInfo.CurrentCulture = new CultureInfo("th-TH", false);
             InitializeComponent();
 
             // default is walking


### PR DESCRIPTION
Added us localization. If default uses "," instead of ".", map api call fails.